### PR TITLE
Update dependency: defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["no_std", "embedded-hal", "bmp280", "sensor", "driver"]
 
 [dependencies]
 embedded-hal = "0.2.4"
-snafu = {version = "0.6.10", default_features = false }
-defmt = "0.1.3"
+snafu = { version = "0.6.10", default_features = false }
+defmt = "0.3.5"
 
 [dev-dependencies]
 embedded-hal-mock = "0.7.2"


### PR DESCRIPTION
The old `defmt` version caused compilation errors (missing `AtomicPtr` and `AtomicU16`) when building for AVR targets. 
